### PR TITLE
Fix wrong database path

### DIFF
--- a/db_interface.php
+++ b/db_interface.php
@@ -16,7 +16,11 @@ class Database {
      * Constructor - establishes connection to the database
      * Tries MySQL first, then falls back to SQLite
      */
-    public function __construct($dbPath = 'pim_database.sqlite') {
+    public function __construct($dbPath = null) {
+        if ($dbPath === null) {
+            // Use database file in the bundled "database" directory by default
+            $dbPath = __DIR__ . '/database/pim_database.sqlite';
+        }
         // Try MySQL connection first
         try {
             $this->db = new PDO('mysql:host=localhost;dbname=pim_database;charset=utf8', 'root', 'MMindthe131!!');


### PR DESCRIPTION
## Summary
- fix SQLite database path so the DB interface uses database/pim_database.sqlite

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684926a4b0f88324ab86b0fc6b7a11dc